### PR TITLE
Swapped security checkers as the SensioLabs one doesn't exist anymore.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,8 +8,8 @@
     "squizlabs/php_codesniffer": "^3.4",
     "sebastian/phpcpd": "4.1.0",
     "jakub-onderka/php-parallel-lint": "1.0.0",
-    "sensiolabs/security-checker": "5.0.3",
-    "drupal/coder": "^8.3"
+    "drupal/coder": "^8.3",
+    "enlightn/security-checker": "^1.7"
   },
   "scripts": {
     "post-install-cmd": [


### PR DESCRIPTION
Hello my brother!

Thanks for your efforts in putting this together. Since `sensiolabs/security-checker` has been archived, the preferred one appears to be `enlightn/security-checker`.

HTH